### PR TITLE
FIx Missing include file: 'Library/PrePiLib.h' #4

### DIFF
--- a/v3x4.inf
+++ b/v3x4.inf
@@ -13,6 +13,7 @@ v3x4.c
 MdePkg/MdePkg.dec
 MdeModulePkg/MdeModulePkg.dec
 UefiCpuPkg/UefiCpuPkg.dec
+EmbeddedPkg/EmbeddedPkg.dec
 
 [LibraryClasses]
 BaseLib


### PR DESCRIPTION
fix Missing include file: 'Library/PrePiLib.h' #4 